### PR TITLE
inline all methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(test, deny(warnings))]
 
 /// Returns how many bytes are needed to encode a value.
+#[inline]
 pub fn length(value: u64) -> usize {
   if value < (1 << 7) {
     1
@@ -30,12 +31,14 @@ pub fn length(value: u64) -> usize {
 
 /// Encode a `u64` integer to the byte slice. Returns how many bytes were
 /// encoded.
+#[inline]
 pub fn encode(value: u64, buf: &mut [u8]) -> usize {
   encode_with_offset(value, buf, 0)
 }
 
 /// Encode a `u64` integer at a specific offset in the byte slice. Returns how
 /// many bytes were encoded.
+#[inline]
 pub fn encode_with_offset(value: u64, buf: &mut [u8], offset: usize) -> usize {
   let mut off = offset;
   let mut val = value;
@@ -52,12 +55,14 @@ pub fn encode_with_offset(value: u64, buf: &mut [u8], offset: usize) -> usize {
 
 /// Decode a byte slice into a `u64` integer. Returns how many bytes were
 /// decoded.
+#[inline]
 pub fn decode(buf: &[u8], value: &mut u64) -> usize {
-  return decode_with_offset(buf, 0, value);
+  decode_with_offset(buf, 0, value)
 }
 
 /// Decode a byte slice into a `u64` integer at a specific offset. Returns how
 /// many bytes were decoded.
+#[inline]
 pub fn decode_with_offset(buf: &[u8], offset: usize, value: &mut u64) -> usize {
   let mut val = 0 as u64;
   let mut fac = 1 as u64;
@@ -79,18 +84,21 @@ pub fn decode_with_offset(buf: &[u8], offset: usize, value: &mut u64) -> usize {
 }
 
 /// Returns how many bytes are needed to encode a value.
+#[inline]
 pub fn signed_length(value: i64) -> usize {
   length(unsign(value))
 }
 
 /// Encode a `i64` (signed) integer at a specific offset in the byte slice.
 /// Returns how many bytes were encoded.
+#[inline]
 pub fn signed_encode(value: i64, buf: &mut [u8]) -> usize {
   encode_with_offset(unsign(value), buf, 0)
 }
 
 /// Encode a `i64` (signed) integer at a specific offset in the byte slice.
 /// Returns how many bytes were encoded.
+#[inline]
 pub fn signed_encode_with_offset(
   value: i64,
   buf: &mut [u8],
@@ -101,12 +109,14 @@ pub fn signed_encode_with_offset(
 
 /// Decode a byte slice into a `i64` (signed) integer.  Returns how many bytes
 /// were decoded.
+#[inline]
 pub fn signed_decode(buf: &[u8], value: &mut i64) -> usize {
   signed_decode_with_offset(buf, 0, value)
 }
 
 /// Decode a byte slice into a `i64` (signed) integer at a specific offset.
 /// Returns how many bytes were decoded.
+#[inline]
 pub fn signed_decode_with_offset(
   buf: &[u8],
   offset: usize,
@@ -119,6 +129,7 @@ pub fn signed_decode_with_offset(
 }
 
 /// Convert an `i64` into a `u64`.
+#[inline]
 fn unsign(value: i64) -> u64 {
   if value >= 0 {
     (value * 2) as u64
@@ -128,6 +139,7 @@ fn unsign(value: i64) -> u64 {
 }
 
 /// Convert a `u64` into a `i64`.
+#[inline]
 fn sign(value: u64) -> i64 {
   if value & 1 != 0 {
     -(((value + 1) / 2) as i64)


### PR DESCRIPTION
LLVM is only able to automatically inlining methods _inside_ crates. `pub` methods need to explicitly be tagged with `#[inline]` to be inlined across crate boundaries.

This tags all methods with `#[inline]`, which should probably speed it up a bunch.

Thanks!

cc/ @mwarning 